### PR TITLE
Added 1.1 PrimitiveTypes, fixed missing comma

### DIFF
--- a/pygdtf/value.py
+++ b/pygdtf/value.py
@@ -46,8 +46,9 @@ class Ces(Enum):
 
 
 class PrimitiveType(Enum):
-    permitted = ['Undefined', 'Cube' 'Cylinder', 'Sphere', 'Base', 'Yoke',
-                 'Head', 'Scanner', 'Conventional', 'Pigtail']
+    permitted = ['Undefined', 'Cube', 'Cylinder', 'Sphere', 'Base', 'Yoke',
+                 'Head', 'Scanner', 'Conventional', 'Pigtail',
+                 'Base1_1', 'Scanner1_1', 'Conventional1_1']
     _default = 'Undefined'
 
 


### PR DESCRIPTION
I'm assuming version 1.1 introduced 3 "new" PrimitiveTypes: "Base1_1", "Scanner1_1", "Conventional1_1".
I've also fixed the [missing comma issue](https://github.com/jackdpage/python-gdtf/issues/2).
